### PR TITLE
Fix formatting in ip_forward.md

### DIFF
--- a/net/ipv4/ip_forward.md
+++ b/net/ipv4/ip_forward.md
@@ -6,7 +6,9 @@ sysctl-file: /proc/sys/net/ipv4/ip_forward
 sysctl-variable: net.ipv4.ip_forward
 source: https://www.kernel.org/doc/Documentation/networking/ip-sysctl.txt
 ---
+
 0 - disabled (default)
+
 not 0 - enabled
 
 Forward Packets between interfaces.


### PR DESCRIPTION
For some options, the formatting is OK:

![image](https://github.com/user-attachments/assets/cc7537f5-e87f-4612-b828-4eed7de2e625)

For `net.ipv4.ip_forward`, it isn't:

![image](https://github.com/user-attachments/assets/0989ea22-fec9-4bc3-9aa0-f63d96b83ba4)
